### PR TITLE
Fix index exception

### DIFF
--- a/langchain_falkordb/message_history.py
+++ b/langchain_falkordb/message_history.py
@@ -117,8 +117,7 @@ class FalkorDBChatMessageHistory(BaseChatMessageHistory):
                 f"{self._node_label}", "id", dim=5, similarity_function="cosine"
             )
         except Exception as e:
-            if "already indexed" in str(e):
-                print(f"{self._node_label} has already been indexed")
+            pass
 
     def _process_records(self, records: list) -> List[BaseMessage]:
         """Process the records from FalkorDB and convert them into BaseMessage objects.

--- a/langchain_falkordb/message_history.py
+++ b/langchain_falkordb/message_history.py
@@ -118,7 +118,7 @@ class FalkorDBChatMessageHistory(BaseChatMessageHistory):
             )
         except Exception as e:
             if "already indexed" in str(e):
-                raise ValueError(f"{self._node_label} has already been indexed")
+                print(f"{self._node_label} has already been indexed")
 
     def _process_records(self, records: list) -> List[BaseMessage]:
         """Process the records from FalkorDB and convert them into BaseMessage objects.


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed exception raising for already indexed nodes.

- Simplified error handling in `create_node_vector_index`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>message_history.py</strong><dd><code>Simplified error handling in `create_node_vector_index`</code>&nbsp; &nbsp; </dd></summary>
<hr>

langchain_falkordb/message_history.py

<li>Removed the specific exception raising for "already indexed".<br> <li> Simplified the <code>try-except</code> block by using <code>pass</code>.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/langchain-falkordb/pull/1/files#diff-138317f93d47cdac323157c34f06d648adc7d20d2daf819bc916e70f899f57c1">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in chat message history initialization to prevent unnecessary interruptions during indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->